### PR TITLE
Switch to Discord link

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -8,7 +8,7 @@ draft: false
 images: []
 ---
 
-{{< my-button-new-page link="https://forum.pollen-robotics.com/" label="Join Pollen Community on our forum!" >}}
+{{< my-button-new-page link="https://discord.gg/vnYD6GAqJR" label="Join Pollen Community on Discord!" >}}
 
 <br />
 <br />


### PR DESCRIPTION
Modify the button in the documentation Homepage to link it to the Discord community rather than the Forum